### PR TITLE
Add postgres connection class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := """scala-jooq-tables"""
 
 organization := "com.harrys"
 
-version := "1.6.2"
+version := "1.6.3"
 
 scalaVersion := "2.11.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,14 @@ exportJars := true
 
 libraryDependencies ++= Seq(
   "org.jooq" % "jooq" % "3.6.2",
-  "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
+  "org.postgresql" % "postgresql" % "9.4-1205-jdbc41",
   "com.typesafe" % "config" % "1.3.0"
+)
+
+lazy val `scala-postgres-utils` = RootProject(uri("ssh://git@github.com/harrystech/scala-postgres-utils.git#v0.1.0"))
+
+lazy val root = (project in file(".")).dependsOn(
+  `scala-postgres-utils`
 )
 
 // --
@@ -22,5 +28,3 @@ libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.12.5" % Test,
   "org.scalatest" %% "scalatest" % "2.2.4" % Test
 )
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
 
 lazy val `scala-postgres-utils` = RootProject(uri("ssh://git@github.com/harrystech/scala-postgres-utils.git#v0.1.0"))
 
-lazy val root = (project in file(".")).dependsOn(
+lazy val `scala-jooq-tables` = (project in file(".")).dependsOn(
   `scala-postgres-utils`
 )
 

--- a/src/main/scala/com/harrys/sql/PostgresConnection.scala
+++ b/src/main/scala/com/harrys/sql/PostgresConnection.scala
@@ -14,9 +14,9 @@ import scala.util.{Failure, Success, Try}
   * Class to aid with executing jOOQ queries within Postgres connections.
   *
   * @param jdbcUrl URL with DSN information, something like postgresql://localhost:5432/public
-  * @param applicationName Optional application name to use for connection (for example, used in pg_stat_activity)
+  * @param applicationName Application name to use for connection (for example, shows up in pg_stat_activity)
   */
-final class PostgresConnection(jdbcUrl: String, applicationName: Option[String] = None) {
+final class PostgresConnection(jdbcUrl: String, applicationName: String) {
 
   if (jdbcUrl == null) {
     throw new IllegalArgumentException("jdbcUrl must not be null!")
@@ -31,8 +31,7 @@ final class PostgresConnection(jdbcUrl: String, applicationName: Option[String] 
 
   def withConnection[T](block: (Connection) => T) = {
     val connection = dataSource.getConnection
-    val appName = applicationName getOrElse block.getClass.getPackage.getName
-    connection.setClientInfo("ApplicationName", appName)
+    connection.setClientInfo("ApplicationName", applicationName)
     connection.setAutoCommit(true)
     try {
       block(connection)
@@ -51,10 +50,11 @@ object PostgresConnectionTest {
   /**
     * Connect to database and execute a "select 1" query to test connection.
     * @param jdbcUrl The connection string with DSN
+    * @param applicationName Application name to use for connection
     * @return A boolean denoting successful connection test
     */
-  def testConnection(jdbcUrl: String): Boolean = {
-    val db = new PostgresConnection(jdbcUrl)
+  def testConnection(jdbcUrl: String, applicationName: String): Boolean = {
+    val db = new PostgresConnection(jdbcUrl, applicationName)
 
     db.tryConnect match {
       case Failure(reason) => false

--- a/src/main/scala/com/harrys/sql/PostgresConnection.scala
+++ b/src/main/scala/com/harrys/sql/PostgresConnection.scala
@@ -1,0 +1,65 @@
+package com.harrys.sql
+
+
+import java.sql.Connection
+
+import org.jooq.impl.DSL
+import org.jooq.{DSLContext, SQLDialect}
+
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Created by tom on 2/9/16.
+  *
+  * Class to aid with executing jOOQ queries within Postgres connections.
+  *
+  * @param jdbcUrl URL with DSN information, something like postgresql://localhost:5432/public
+  * @param applicationName Optional application name to use for connection (for example, used in pg_stat_activity)
+  */
+final class PostgresConnection(jdbcUrl: String, applicationName: Option[String] = None) {
+
+  if (jdbcUrl == null) {
+    throw new IllegalArgumentException("jdbcUrl must not be null!")
+  }
+
+  // The jdbc parser is in scala-postgres-utils.
+  private val dataSource = PostgresJdbcParser.parseJdbcUrlForDataSource(jdbcUrl)
+
+  def withDSLContext[T](block: (DSLContext) => T): T = {
+    withConnection(c => block(DSL.using(c, SQLDialect.POSTGRES)))
+  }
+
+  def withConnection[T](block: (Connection) => T) = {
+    val connection = dataSource.getConnection
+    val appName = applicationName getOrElse block.getClass.getPackage.getName
+    connection.setClientInfo("ApplicationName", appName)
+    connection.setAutoCommit(true)
+    try {
+      block(connection)
+    } finally {
+      connection.close()
+    }
+  }
+
+  def tryConnect(): Try[Boolean] = Try(this.withDSLContext(_.selectOne().fetchOne().value1() == 1))
+
+}
+
+
+object PostgresConnectionTest {
+
+  /**
+    * Connect to database and execute a "select 1" query to test connection.
+    * @param jdbcUrl The connection string with DSN
+    * @return A boolean denoting successful connection test
+    */
+  def testConnection(jdbcUrl: String): Boolean = {
+    val db = new PostgresConnection(jdbcUrl)
+
+    db.tryConnect match {
+      case Failure(reason) => false
+      case Success(result) => result
+    }
+
+  }
+}


### PR DESCRIPTION
Adds connection and connection test, something like:
```scala
val db = new PostgresConnection(sourceConfiguration.jdbcUrl, getClass.getCanonicalName)
db.withDSLContext(implicit context =>  /* code block */ )
```

@pettyjamesm @triplec1988 Refactoring connection code