### PR TITLE
Docker build container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .idea/
+
+# Unmanaged dependencies
+lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Provides the run time container image for local testing of Hyppo Manager. Derived from the base Dockerfile in the ingestion-utils repo.
+# Provides the build container for this project. Derived from the base Dockerfile in the ingestion-utils repo.
 #
 FROM hyppo-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+#
+# Provides the run time container image for local testing of Hyppo Manager. Derived from the base Dockerfile in the ingestion-utils repo.
+#
+FROM hyppo-build
+
+COPY . /app/
+
+RUN /usr/local/sbt/bin/sbt packageBin

--- a/build.sbt
+++ b/build.sbt
@@ -18,14 +18,10 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.0"
 )
 
-lazy val `scala-postgres-utils` = RootProject(uri("ssh://git@github.com/harrystech/scala-postgres-utils.git#v0.1.2"))
-
-lazy val `scala-jooq-tables` = (project in file(".")).dependsOn(
-  `scala-postgres-utils`
-)
-
-// This forces the scala version used between these to match
-scalaVersion in `scala-postgres-utils` := (scalaVersion in `scala-jooq-tables`).value
+// Removed git based libraries in favor of pre-compiled libs.
+// Please refer to the README in https://github.com/harrystech/ingestion-utils
+// Depends on:
+//   * https://github.com/harrystech/scala-postgres-utils
 
 // --
 //  Test Setup


### PR DESCRIPTION
Docker container that can be used to build this project's JAR file. This is pretty hacky right now; the objective was to just get some working local environment quickly. The git-based project dependency on scala-postgres-utils is problematic for Docker, because the git credentials aren't available inside the container. So we just ripped it out and manually stuck the compiled JAR in lib/.